### PR TITLE
Allow to pass a custom refs resolver store when adding an api

### DIFF
--- a/especifico/apis/abstract.py
+++ b/especifico/apis/abstract.py
@@ -53,6 +53,7 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
         pythonic_params=False,
         pass_context_arg_name=None,
         options=None,
+        ref_resolver_store=None,
     ):
         """
         :type specification: pathlib.Path | dict
@@ -93,7 +94,9 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
         )
 
         # Avoid validator having ability to modify specification
-        self.specification = Specification.load(specification, arguments=arguments)
+        self.specification = Specification.load(
+            specification, arguments=arguments, ref_resolver_store=ref_resolver_store,
+        )
 
         logger.debug("Read specification", extra={"spec": self.specification})
 

--- a/especifico/apps/abstract.py
+++ b/especifico/apps/abstract.py
@@ -117,6 +117,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
         pass_context_arg_name=None,
         options=None,
         validator_map=None,
+        ref_resolver_store=None,
     ):
         """
         Adds an API to the application based on a swagger file or API dict
@@ -185,6 +186,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
             pythonic_params=pythonic_params,
             pass_context_arg_name=pass_context_arg_name,
             options=api_options.as_dict(),
+            ref_resolver_store=ref_resolver_store,
         )
         return api
 


### PR DESCRIPTION
This permits for instance to avoid network access for URLs referred in the API schema:

schema.yaml:
...
field:
  $ref: https://a.org/my_referred_schema.yaml$/components/schemas/FieldDef

Python code:

custom_ref_store = {"https://a.org/my_referred_schema.yaml":  {....}} app.add_api('schema.yaml', ref_resolver_store=custom_ref_store)

Fixes #.
