### PR TITLE
Do not resolve refs in nested jsonschema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv/
 .venv/
 src/
 *.un~
+/coverage.xml

--- a/especifico/apis/abstract.py
+++ b/especifico/apis/abstract.py
@@ -81,6 +81,7 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
         self.debug = debug
         self.validator_map = validator_map
         self.resolver_error_handler = resolver_error_handler
+        self._ref_resolver_store = ref_resolver_store
 
         logger.debug(
             "Loading specification: %s",
@@ -208,6 +209,7 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
             pythonic_params=self.pythonic_params,
             uri_parser_class=self.options.uri_parser_class,
             pass_context_arg_name=self.pass_context_arg_name,
+            ref_resolver_store=self._ref_resolver_store,
         )
         self._add_operation_internal(method, path, operation)
 

--- a/especifico/decorators/response.py
+++ b/especifico/decorators/response.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("especifico.decorators.response")
 
 
 class ResponseValidator(BaseDecorator):
-    def __init__(self, operation, mimetype, validator=None):
+    def __init__(self, operation, mimetype, validator=None, ref_resolver_store=None):
         """
         :type operation: Operation
         :type mimetype: str
@@ -29,6 +29,7 @@ class ResponseValidator(BaseDecorator):
         self.operation = operation
         self.mimetype = mimetype
         self.validator = validator
+        self._ref_resolver_store = ref_resolver_store
 
     def validate_response(self, data, status_code, headers, url):
         """
@@ -47,7 +48,11 @@ class ResponseValidator(BaseDecorator):
         response_schema = self.operation.response_schema(str(status_code), content_type)
 
         if self.is_json_schema_compatible(response_schema, content_type):
-            v = ResponseBodyValidator(response_schema, validator=self.validator)
+            v = ResponseBodyValidator(
+                response_schema,
+                validator=self.validator,
+                ref_resolver_store=self._ref_resolver_store,
+            )
             try:
                 data = self.operation.json_loads(data)
             except ValueError as e:

--- a/especifico/decorators/validation.py
+++ b/especifico/decorators/validation.py
@@ -112,6 +112,7 @@ class RequestBodyValidator:
         is_null_value_valid=False,
         validator=None,
         strict_validation=False,
+        ref_resolver_store=None,
     ):
         """
         :param schema: The schema of the request body
@@ -127,7 +128,11 @@ class RequestBodyValidator:
         self.has_default = schema.get("default", False)
         self.is_null_value_valid = is_null_value_valid
         validatorClass = validator or Draft4RequestValidator
-        self.validator = validatorClass(schema, format_checker=draft4_format_checker)
+        resolver = _build_ref_resolver(ref_resolver_store, schema)
+        self.validator = validatorClass(
+            schema, format_checker=draft4_format_checker, resolver=resolver,
+        )
+
         self.api = api
         self.strict_validation = strict_validation
 

--- a/especifico/decorators/validation.py
+++ b/especifico/decorators/validation.py
@@ -265,8 +265,7 @@ class ParameterValidator:
         self.api = api
         self.strict_validation = strict_validation
 
-    @staticmethod
-    def validate_parameter(parameter_type, value, param, param_name=None):
+    def validate_parameter(self, parameter_type, value, param, param_name=None):
         if value is not None:
             if is_nullable(param) and is_null(value):
                 return

--- a/especifico/decorators/validation.py
+++ b/especifico/decorators/validation.py
@@ -233,7 +233,7 @@ class RequestBodyValidator:
 
 
 class ResponseBodyValidator:
-    def __init__(self, schema, validator=None):
+    def __init__(self, schema, validator=None, ref_resolver_store=None):
         """
         :param schema: The schema of the response body
         :param validator: Validator class that should be used to validate passed data
@@ -241,7 +241,11 @@ class ResponseBodyValidator:
         :type validator: jsonschema.IValidator
         """
         ValidatorClass = validator or Draft4ResponseValidator
-        self.validator = ValidatorClass(schema, format_checker=draft4_format_checker)
+        if ref_resolver_store is None:
+            resolver = None
+        else:
+            resolver = RefResolver.from_schema(schema, store=ref_resolver_store)
+        self.validator = ValidatorClass(schema, format_checker=draft4_format_checker, resolver=resolver)
 
     def validate_schema(self, data: dict, url: str) -> Union[EspecificoResponse, None]:
         try:

--- a/especifico/operations/abstract.py
+++ b/especifico/operations/abstract.py
@@ -477,7 +477,9 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         :rtype: types.FunctionType
         """
         ResponseValidator = self.validator_map["response"]
-        return ResponseValidator(self, self.get_mimetype())
+        return ResponseValidator(
+            self, self.get_mimetype(), ref_resolver_store=self._ref_resolver_store,
+        )
 
     def json_loads(self, data):
         """

--- a/especifico/operations/abstract.py
+++ b/especifico/operations/abstract.py
@@ -61,6 +61,7 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         pythonic_params=False,
         uri_parser_class=None,
         pass_context_arg_name=None,
+        ref_resolver_store=None,
     ):
         """
         :param api: api that this operation is attached to
@@ -107,6 +108,7 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         self._pythonic_params = pythonic_params
         self._uri_parser_class = uri_parser_class
         self._pass_context_arg_name = pass_context_arg_name
+        self._ref_resolver_store = ref_resolver_store
         self._randomize_endpoint = randomize_endpoint
 
         self._operation_id = self._operation.get("operationId")
@@ -453,7 +455,10 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         RequestBodyValidator = self.validator_map["body"]
         if self.parameters:
             yield ParameterValidator(
-                self.parameters, self.api, strict_validation=self.strict_validation,
+                self.parameters,
+                self.api,
+                strict_validation=self.strict_validation,
+                ref_resolver_store=self._ref_resolver_store,
             )
         if self.body_schema:
             yield RequestBodyValidator(

--- a/especifico/operations/abstract.py
+++ b/especifico/operations/abstract.py
@@ -467,6 +467,7 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
                 self.api,
                 is_nullable(self.body_definition),
                 strict_validation=self.strict_validation,
+                ref_resolver_store=self._ref_resolver_store,
             )
 
     @property

--- a/especifico/operations/openapi.py
+++ b/especifico/operations/openapi.py
@@ -37,6 +37,7 @@ class OpenAPIOperation(AbstractOperation):
         pythonic_params=False,
         uri_parser_class=None,
         pass_context_arg_name=None,
+        ref_resolver_store=None,
     ):
         """
         This class uses the OperationID identify the module and function that will handle the operation
@@ -106,6 +107,7 @@ class OpenAPIOperation(AbstractOperation):
             pythonic_params=pythonic_params,
             uri_parser_class=uri_parser_class,
             pass_context_arg_name=pass_context_arg_name,
+            ref_resolver_store=ref_resolver_store,
         )
 
         self._definitions_map = {

--- a/especifico/operations/swagger2.py
+++ b/especifico/operations/swagger2.py
@@ -48,6 +48,7 @@ class Swagger2Operation(AbstractOperation):
         pythonic_params=False,
         uri_parser_class=None,
         pass_context_arg_name=None,
+        ref_resolver_store=None,
     ):
         """
         :param api: api that this operation is attached to
@@ -115,6 +116,7 @@ class Swagger2Operation(AbstractOperation):
             pythonic_params=pythonic_params,
             uri_parser_class=uri_parser_class,
             pass_context_arg_name=pass_context_arg_name,
+            ref_resolver_store=ref_resolver_store,
         )
 
         self._produces = operation.get("produces", app_produces)


### PR DESCRIPTION
Fixes https://github.com/spec-first/connexion/issues/1607

Resolving `$ref` inside the `jsonschema`s nested in the OpenAPI specification is a source of problems. For example a spec with cycles is generated if the are circular $ref-s chains (allowed by jsonschema).

This PR do not resolve $ref-s anymore inside the nested jsonschemas.
The library really needs $ref-s to be resolved only in the OAS specific part, for instance
```
    post:
      parameters:
      - $ref: '#/components/parameters/SomeSchema'
```
since it has extra business logic on the resolved values.
The `$ref-s` inside nested jsonschemas can be left as they are, will be handled by the jsonschema library when applying schemas for validation.

Not resolving every `$ref` in spec required a second change.
The recently introduced `ref_resolver_store` was not passed to the validators, only to `resolve_refs()`.
This caused `jsonschema` library to make a network call when applying the schemas, since they still contain unresolved $ref-s.
Now the `ref_resolver_store` passed to `add_api()` is used by every validator. 
  
