### PR TITLE
Fix deprecation warning for Validator.iter_errors (#1536)

### DIFF
--- a/especifico/spec.py
+++ b/especifico/spec.py
@@ -52,7 +52,7 @@ def create_spec_validator(spec: dict) -> Draft4Validator:
         if not valid:
             return
         if isinstance(instance, dict) and "default" in instance:
-            for error in instance_validator.iter_errors(instance["default"], instance):
+            for error in instance_validator.evolve(schema=instance).iter_errors(instance["default"]):
                 yield error
 
     SpecValidator = extend_validator(Draft4Validator, {"properties": validate_defaults})


### PR DESCRIPTION
* Fix deprecation warning for iter_errors Bump jsonschema version to at least v4

* Bump jsonschema to v4.0.1

* Provide schema as keyword arg to evolve

* Fix evolve statement

Fixes #.
